### PR TITLE
v2.0.0-beta.3

### DIFF
--- a/ms2rescore/__init__.py
+++ b/ms2rescore/__init__.py
@@ -245,4 +245,4 @@ class MS2ReScore:
         if self.config["general"]["run_percolator"]:
             self._run_percolator()
 
-        logging.info("MS²ReScore finished!")
+        logger.info("MS²ReScore finished!")

--- a/ms2rescore/_version.py
+++ b/ms2rescore/_version.py
@@ -1,3 +1,3 @@
 """Single source of ms2rescore version number."""
 
-__version__ = "2.0.0-beta.2"
+__version__ = "2.0.0-beta.3"

--- a/ms2rescore/id_file_parser.py
+++ b/ms2rescore/id_file_parser.py
@@ -291,8 +291,9 @@ class TandemPipeline(_Pipeline):
         pin = self.original_pin
         pin.add_peprec_modifications_column()
         pin.add_spectrum_index_column(label="tandem_id")
+        pin.df["ModPeptide"] = pin.df["Peptide"]
         peprec_df = peprec_df.merge(
-            pin.df[["modifications", "tandem_id", "hyperscore", "Label"]],
+            pin.df[["modifications", "tandem_id", "hyperscore", "Label", "ModPeptide", "Proteins"]],
             on="tandem_id"
         )
         # Validate merge by comparing the hyperscore columns

--- a/ms2rescore/percolator.py
+++ b/ms2rescore/percolator.py
@@ -391,7 +391,8 @@ class PercolatorIn:
             "charge",
             "observed_retention_time"
         ]
-        non_feature_cols = pin_cols + peprec_cols
+        misc_cols = ["tandem_id", "ModPeptide"]
+        non_feature_cols = pin_cols + peprec_cols + misc_cols
         feature_cols = [col for col in self.df.columns if col not in non_feature_cols]
         return self.df[feature_cols]
 

--- a/ms2rescore/retention_time.py
+++ b/ms2rescore/retention_time.py
@@ -63,6 +63,10 @@ class RetentionTimeIntegration:
         self.calibration_set_size = calibration_set_size
         self.num_cpu = num_cpu
 
+        # Until fixed upstream: https://github.com/compomics/DeepLC/issues/19
+        if "NUMEXPR_MAX_THREADS" not in os.environ:
+            os.environ['NUMEXPR_MAX_THREADS'] = str(self.num_cpu)
+
         from deeplc import DeepLC
 
         self.deeplc_predictor = DeepLC(


### PR DESCRIPTION
New: 
- X!Tandem pipeline outputs flanking amino acids to PIN file (#24, #27)

Fixed:
- Temporary fix for Tensorflow NUMEXPR_MAX_THREADS (#25, compomics/DeepLC#19)
- `tandem_id` column was erroneously written to X!Tandem PIN files
- Use logger instead of logging