### PR TITLE
Streamlit webserver

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   publish:
@@ -26,7 +26,7 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python setup.py sdist bdist_wheel
-        
+
     - name: Test built package
       run: |
         pip install dist/ms2rescore-*.whl
@@ -42,3 +42,15 @@ jobs:
       with:
         user: ${{ secrets.PYPI_USERNAME }}
         password: ${{ secrets.PYPI_PASSWORD }}
+
+  build-streamlit-image:
+    runs-on: ubuntu-latest
+    needs: publish
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build and push to ghcr.io
+      uses: docker/build-push-action@v2
+      with:
+        context: streamlit
+        push: true
+        tags: ghcr.io/compomics/ms2rescore-streamlit:${{ github.event.release.tag_name }}

--- a/ms2rescore/__init__.py
+++ b/ms2rescore/__init__.py
@@ -77,11 +77,10 @@ class MS2ReScore:
     def _validate_cli_dependency(command):
         """Validate that command returns zero exit status."""
         if subprocess.getstatusoutput(command)[0] != 0:
-            logger.critical(
-                "`%s` returned non-zero exit status. Please verify installation.",
-                command,
+            raise MS2ReScoreError(
+                f"`{command}` returned non-zero exit status. Please verify "
+                "installation.",
             )
-            exit(1)
 
     @staticmethod
     def _infer_pipeline(identification_file: str):
@@ -131,7 +130,7 @@ class MS2ReScore:
         num_cpu: int,
     ):
         """Get predicted MS² peak intensities from MS2PIP."""
-        logger.info("Adding MS2 peak intensity features with MS²PIP.")
+        logger.info("Adding MS2 peak intensity features with MS²PIP...")
         ms2pip_config_filename = output_filename + "_ms2pip_config.txt"
         rescore_core.make_ms2pip_config(ms2pip_config, filename=ms2pip_config_filename)
 
@@ -147,7 +146,7 @@ class MS2ReScore:
         logger.debug("Running MS2PIP: %s", ms2pip_command)
         subprocess.run(ms2pip_command, shell=True, check=True)
 
-        logger.info("Calculating features from predicted spectra")
+        logger.info("Calculating features from predicted spectra...")
         preds_filename = (
             peprec_filename.replace(".peprec", "")
             + "_"
@@ -165,7 +164,7 @@ class MS2ReScore:
         num_cpu: int,
     ):
         """Get retention time features with DeepLC."""
-        logger.info("Adding retention time features with DeepLC.")
+        logger.info("Adding retention time features with DeepLC...")
         rt_int = RetentionTimeIntegration(
             peprec_filename, output_filename + "_rtfeatures.csv", num_cpu=num_cpu,
         )
@@ -196,7 +195,7 @@ class MS2ReScore:
             subprocess.run(percolator_cmd, shell=True)
 
             if not os.path.isfile(subname + ".pout"):
-                logger.error("Error running Percolator")
+                logger.error("Error running Percolator for %s feature set.", subset)
 
     def run(self):
         """Run MS²ReScore."""
@@ -232,7 +231,7 @@ class MS2ReScore:
                 self.config["general"]["num_cpu"],
             )
 
-        logger.info("Generating PIN files")
+        logger.info("Generating PIN files...")
         rescore_core.write_pin_files(
             peprec_filename,
             self.config["general"]["output_filename"],

--- a/ms2rescore/__main__.py
+++ b/ms2rescore/__main__.py
@@ -14,7 +14,7 @@ def main():
         rescore = MS2ReScore(parse_cli_args=True, configuration=None, set_logger=True)
         rescore.run()
     except Exception:
-        logger.exception("Critical error occured in MS2ReScore")
+        logger.exception("Critical error occured in MS2ReScore.")
 
 
 if __name__ == "__main__":

--- a/ms2rescore/_version.py
+++ b/ms2rescore/_version.py
@@ -1,3 +1,3 @@
 """Single source of ms2rescore version number."""
 
-__version__ = "2.0.0-beta.5"
+__version__ = "2.0.0-beta.6"

--- a/ms2rescore/config_parser.py
+++ b/ms2rescore/config_parser.py
@@ -137,7 +137,7 @@ def parse_config(parse_cli_args: bool = True, config_class: Optional[Dict] = Non
             )
     elif config_class:
         args = None
-        config_user = config_class["config_file"]
+        config_user = None
     else:
         raise MS2ReScoreConfigurationError(
             "If `parse_cli_args` is False, `config_class` arguments are required."
@@ -150,7 +150,7 @@ def parse_config(parse_cli_args: bool = True, config_class: Optional[Dict] = Non
     if parse_cli_args:
         cascade_conf.add_namespace(args, subkey="general")
     elif config_class:
-        cascade_conf.add_dict(config_class, subkey="general")
+        cascade_conf.add_dict(config_class)
     config = cascade_conf.parse()
 
     config = _validate_filenames(config)

--- a/ms2rescore/id_file_parser.py
+++ b/ms2rescore/id_file_parser.py
@@ -341,7 +341,7 @@ class MaxQuantPipeline(_Pipeline):
         if not self._path_to_new_mgf:
             logger.warning(
                 "`_path_to_new_mgf` is not set yet; first run the `parse_mgf_files` "
-                "method"
+                "method."
             )
         else:
             return self._path_to_new_mgf
@@ -368,7 +368,7 @@ class MaxQuantPipeline(_Pipeline):
 
     def parse_mgf_files(self, peprec):
         """Parse multiple MGF files into one for MS²PIP."""
-        logger.debug("Parsing MGF files into one for MS²PIP")
+        logger.debug("Parsing MGF files into one for MS²PIP...")
         path_to_new_mgf = self.output_basename + "_unified.mgf"
         parse_mgf(
             peprec.df,

--- a/ms2rescore/peptideshaker.py
+++ b/ms2rescore/peptideshaker.py
@@ -43,7 +43,7 @@ class ExtendedPsmReportAccessor:
         ].index
         if len(to_drop) > 0:
             logger.warning(
-                "Dropping %i PSMs from report due to invalid amino acids (%s)",
+                "Dropping %i PSMs from report due to invalid amino acids (%s)...",
                 len(to_drop),
                 invalid_amino_acids
             )

--- a/ms2rescore/percolator.py
+++ b/ms2rescore/percolator.py
@@ -321,7 +321,7 @@ class PercolatorIn:
         ].index
         if len(to_drop) > 0:
             logger.warning(
-                "Dropping %i PSMs from PIN due to invalid amino acids (%s)",
+                "Dropping %i PSMs from PIN due to invalid amino acids (%s)...",
                 len(to_drop),
                 self.invalid_amino_acids
             )
@@ -457,7 +457,7 @@ class PercolatorIn:
                 if col in self.df.columns:
                     score_column_label = col
                     logger.debug(
-                        "Found score column in PIN with label %s", score_column_label
+                        "Found score column in PIN with label %s.", score_column_label
                     )
                     break
             if not score_column_label:
@@ -524,7 +524,7 @@ def run_percolator_converter(
         os.path.abspath(path_to_id_file),
     ]
 
-    logger.info("Running Percolator PIN converter")
+    logger.info("Running Percolator PIN converter...")
     logger.debug(' '.join(command))
 
     subprocess.run(command, capture_output=log_level == "debug", check=True)

--- a/ms2rescore/rescore_core.py
+++ b/ms2rescore/rescore_core.py
@@ -330,13 +330,13 @@ def calculate_features(
     parallelize calculation of features and write them into a csv file
     """
 
-    logger.debug("Reading MS2PIP predictions file")
+    logger.debug("Reading MS2PIP predictions file...")
     df = pd.read_csv(path_to_pred_and_emp)
     df[["prediction", "target"]] = df[["prediction", "target"]].clip(
         lower=np.log2(0.001)
     )
 
-    logger.debug("Computing features")
+    logger.debug("Computing features...")
     if len(df["spec_id"].unique()) < 10000:
         all_results = compute_features(df)
     else:
@@ -368,7 +368,7 @@ def calculate_features(
                 all_results = list(p.imap(compute_features, split_df))
         all_results = pd.concat(all_results)
 
-    logger.debug("Writing to file")
+    logger.debug("Writing to file...")
     all_results.to_csv(path_to_out, index=False)
 
 
@@ -444,8 +444,7 @@ def write_pin_files(
     with open(peprec_path, "rt") as f:
         line = f.readline()
         if line[:7] != "spec_id":
-            logger.critical("PEPREC file should start with header column")
-            exit(1)
+            raise MS2ReScoreError("PEPREC file should start with header column.")
         sep = line[7]
 
     # Convert Protein literal list to pseudo-PIN notation:

--- a/ms2rescore/retention_time.py
+++ b/ms2rescore/retention_time.py
@@ -109,7 +109,7 @@ class RetentionTimeIntegration:
                 "Expected float or int for `calibration_set_size`. Got "
                 f"{type(self.calibration_set_size)} instead"
             )
-        logger.debug("Using %i PSMs for calibration", num_calibration_psms)
+        logger.debug("Using %i PSMs for calibration.", num_calibration_psms)
         return num_calibration_psms
 
     @property

--- a/ms2rescore/setup_logging.py
+++ b/ms2rescore/setup_logging.py
@@ -1,5 +1,6 @@
 import logging
 
+from ms2rescore._exceptions import MS2ReScoreError
 
 def setup_logging(passed_level):
     log_mapping = {
@@ -11,11 +12,10 @@ def setup_logging(passed_level):
     }
 
     if passed_level not in log_mapping:
-        print(
-            "Invalid log level. Should be one of the following: ",
+        raise MS2ReScoreError(
+            "Invalid log level. Should be one of the following: %s",
             ', '.join(log_mapping.keys())
         )
-        exit(1)
 
     logging.basicConfig(
         format='%(asctime)s // %(levelname)s // %(name)s // %(message)s',

--- a/streamlit/Dockerfile
+++ b/streamlit/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:stable-slim as percolator
+RUN apt-get update && apt-get install -y --no-install-recommends wget tar gzip ca-certificates
+WORKDIR /tmp
+ARG PERCOLATOR_VERSION=3-05
+RUN wget https://github.com/percolator/percolator/releases/download/rel-${PERCOLATOR_VERSION}/ubuntu.tar.gz && \
+    tar -xzf ubuntu.tar.gz
+
+FROM python:3.8-buster
+ARG PERCOLATOR_VERSION=3-05
+COPY --from=percolator /tmp/percolator-noxml-v${PERCOLATOR_VERSION}-linux-amd64.deb /tmp
+COPY --from=percolator /tmp/percolator-converters-v${PERCOLATOR_VERSION}-linux-amd64.deb /tmp
+RUN dpkg -i /tmp/percolator-noxml-v${PERCOLATOR_VERSION}-linux-amd64.deb && \
+    dpkg -i /tmp/percolator-converters-v${PERCOLATOR_VERSION}-linux-amd64.deb && \
+    rm /tmp/percolator-noxml-v${PERCOLATOR_VERSION}-linux-amd64.deb && \
+    rm /tmp/percolator-converters-v${PERCOLATOR_VERSION}-linux-amd64.deb
+COPY . .
+RUN pip install -r requirements.txt
+EXPOSE 8501
+CMD ["streamlit", "run", "ms2rescore_streamlit.py"]

--- a/streamlit/ms2rescore_streamlit.py
+++ b/streamlit/ms2rescore_streamlit.py
@@ -1,0 +1,180 @@
+"""Streamlit-based web interface for MS²ReScore."""
+
+import json
+import logging
+import os
+import shutil
+import tempfile
+from glob import glob
+from typing import Dict
+
+import streamlit as st
+from ms2rescore import MS2ReScore
+
+from streamlit_utils import StreamlitLogger, bytesio_to_tempfile, get_zipfile_href
+
+
+class StreamlitUI:
+    """MS²ReScore Streamlit UI."""
+
+    def __init__(self):
+        """MS²ReScore Streamlit UI."""
+        self.user_input = dict()
+
+        st.set_page_config(
+            page_title="MS²ReScore webserver",
+            page_icon=":rocket:",
+            layout="centered",
+            initial_sidebar_state="expanded",
+        )
+
+        self._sidebar()
+        self._main_page()
+
+    def _main_page(self):
+        st.title("MS²ReScore")
+        st.header("About")
+        st.markdown(
+            """
+            MS²ReScore performs sensitive peptide identification rescoring with
+            predicted spectra using [MS²PIP](https://github.com/compomics/ms2pip_c),
+            [DeepLC](https://github.com/compomics/deeplc), and
+            [Percolator](https://github.com/percolator/percolator/). This results in
+            more confident peptide identifications, which allows you to get
+            **more peptide IDs** at the same false discovery rate (FDR) threshold, or
+            to set a **more stringent FDR threshold** while still retaining a similar
+            number of peptide IDs. MS²ReScore is **ideal for challenging proteomics
+            identification workflows**, such as proteogenomics, metaproteomics, or
+            immunopeptidomics.
+
+            MS²ReScore uses identifications from a
+            [Percolator IN (PIN) file](https://github.com/percolator/percolator/wiki/Interface#tab-delimited-file-format),
+            or from the output of one of these search engines:
+
+            - [MaxQuant](https://www.maxquant.org/): Start from `msms.txt`
+            identification file and directory with `.mgf` files. (Be sure to export
+            without FDR filtering!)
+            - [MSGFPlus](https://omics.pnl.gov/software/ms-gf): Start with an `.mzid`
+            identification file and corresponding `.mgf`.
+            - [X!Tandem](https://www.thegpm.org/tandem/): Start with an X!Tandem `.xml`
+            identification file and corresponding `.mgf`.
+            - [PeptideShaker](http://compomics.github.io/projects/peptide-shaker): Start
+            with a PeptideShaker Extended PSM Report and corresponding `.mgf` file.
+
+            If you use MS²ReScore for your research, please cite the following article:
+
+            > **Accurate peptide fragmentation predictions allow data driven approaches to replace
+            and improve upon proteomics search engine scoring functions.** Ana S C Silva, Robbin
+            Bouwmeester, Lennart Martens, and Sven Degroeve. _Bioinformatics_ (2019)
+            [doi:10.1093/bioinformatics/btz383](https://doi.org/10.1093/bioinformatics/btz383)
+
+            This webserver allows file uploads of maximum 1GB. To rescore larger files,
+            you can use the
+            [MS²ReScore Python package](https://github.com/compomics/ms2rescore#installation)
+            """
+        )
+
+        st.header("Input files")
+        self.user_input["id_bytesio"] = st.file_uploader("Identification file")
+        self.user_input["mgf_bytesio"] = st.file_uploader("MGF spectrum file")
+
+        if st.button("Run MS²ReScore"):
+            self._run_ms2rescore()
+
+    def _sidebar(self):
+        st.sidebar.header("Configuration")
+        self.user_input["pipeline"] = st.sidebar.selectbox(
+            "Identification file type",
+            ["pin", "tandem", "maxquant", "msgfplus", "peptideshaker"],
+            index=1,
+        )
+        self.user_input["feature_sets"] = st.sidebar.multiselect(
+            "Feature set combinations to use",
+            ["all", "ms2pip_rt", "searchengine", "rt", "ms2pip"],
+            default=["searchengine"],
+            help="Feature sets for which to generate PIN files and optionally run "
+            "Percolator.",
+        )
+        self.user_input["ms2pip_model"] = st.sidebar.radio(
+            "MS²PIP model",
+            ["HCD", "CID", "TMT", "iTRAQ", "iTRAQphospho", "TTOF5600"],
+            help="MS²PIP model to use (see MS²PIP: https://github.com/compomics/ms2pip_c#ms-acquisition-information-and-peptide-properties-of-the-models-training-datasets)",
+        )
+        self.user_input["config_json"] = st.sidebar.text_area(
+            "Advanced JSON configuration",
+            value='{"general": {}}',
+            help="Set advanced MS²ReScore settings in JSON format (see https://github.com/compomics/ms2rescore/blob/master/configuration.md)",
+        )
+        st.sidebar.markdown(
+            """
+            See [MS²ReScore GitHub](https://github.com/compomics/ms2rescore/blob/master/configuration.md)
+            for all configuration details.
+            """
+        )
+
+    @staticmethod
+    def _parse_user_config(user_input: Dict, tmp_dir) -> Dict:
+        if not user_input["id_bytesio"]:
+            st.error("Please upload an identification file.")
+        elif not user_input["mgf_bytesio"]:
+            st.error("Please upload an MGF file.")
+        else:
+            id_path = bytesio_to_tempfile(user_input["id_bytesio"])
+            mgf_path = bytesio_to_tempfile(user_input["mgf_bytesio"])
+
+        config_dict = _update_dict_recursively(
+            json.loads(user_input["config_json"]),
+            {
+                "general": {
+                    "identification_file": id_path,
+                    "mgf_path": mgf_path,
+                    "feature_sets": user_input["feature_sets"],
+                    "pipeline": user_input["pipeline"],
+                    "output_filename": os.path.join(
+                        tmp_dir.name, user_input["id_bytesio"].name
+                    ),
+                },
+                "ms2pip": {"model": user_input["ms2pip_model"]},
+            },
+        )
+        return config_dict
+
+    def _run_ms2rescore(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        config_dict = self._parse_user_config(self.user_input, tmp_dir)
+
+        try:
+            logger_placeholder = st.empty()
+            logger_name = "ms2rescore"
+            with StreamlitLogger(logger_placeholder, logger_name):
+                logging.info("Starting MS²ReScore...")
+                rescore = MS2ReScore(
+                    parse_cli_args=False, configuration=config_dict, set_logger=False
+                )
+                rescore.run()
+        except Exception as e:
+            st.exception(e)
+
+        st.markdown(
+            get_zipfile_href(
+                glob(config_dict["general"]["output_filename"] + "_*"),
+                filename="ms2rescore_results.zip",
+            ),
+            unsafe_allow_html=True,
+        )
+
+        shutil.rmtree(tmp_dir.name)
+
+
+def _update_dict_recursively(original, updater):
+    """Update dictionary recursively."""
+    for k, v in updater.items():
+        if isinstance(v, dict):
+            original[k] = _update_dict_recursively(original.get(k, {}), v)
+        else:
+            original[k] = v
+    return original
+
+
+if __name__ == "__main__":
+    StreamlitUI()

--- a/streamlit/ms2rescore_streamlit.py
+++ b/streamlit/ms2rescore_streamlit.py
@@ -11,7 +11,12 @@ from typing import Dict
 import streamlit as st
 from ms2rescore import MS2ReScore
 
-from streamlit_utils import StreamlitLogger, bytesio_to_tempfile, get_zipfile_href
+from streamlit_utils import (
+    StreamlitLogger,
+    hide_streamlit_menu,
+    bytesio_to_tempfile,
+    get_zipfile_href
+)
 
 
 class StreamlitUI:
@@ -27,6 +32,8 @@ class StreamlitUI:
             layout="centered",
             initial_sidebar_state="expanded",
         )
+
+        hide_streamlit_menu()
 
         self._sidebar()
         self._main_page()

--- a/streamlit/requirements.txt
+++ b/streamlit/requirements.txt
@@ -1,0 +1,2 @@
+ms2rescore[deeplc]>= 2.0.0b5
+streamlit

--- a/streamlit/requirements.txt
+++ b/streamlit/requirements.txt
@@ -1,2 +1,3 @@
 ms2rescore[deeplc]>= 2.0.0b5
 streamlit
+tomlkit

--- a/streamlit/streamlit_utils.py
+++ b/streamlit/streamlit_utils.py
@@ -1,0 +1,97 @@
+"""Streamlit utils."""
+
+import base64
+import io
+import logging
+import os
+import tempfile
+import zipfile
+from typing import BinaryIO
+
+
+def bytesio_to_tempfile(bytesio: BinaryIO) -> str:
+    """Write BytesIO object to temporary file."""
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        tmp.write(bytesio.getbuffer())
+        filepath = tmp.name
+    return filepath
+
+
+class StreamlitLogger:
+    """Pickup logger and write to Streamlit front end."""
+
+    def __init__(self, placeholder, logger_name=None, accumulate=True, persist=True):
+        """
+        Pickup logger and write to Streamlit front end.
+
+        Parameters
+        ----------
+            placeholder: streamlit.empty
+                Streamlit placeholder object on which to write logs.
+            logger_name: str, optional
+                Module name of logger to pick up. Leave to None to pick up root logger.
+            accumulate: boolean, optional
+                Whether to accumulate log messages or to overwrite with each new
+                message, keeping only the last line. (default: True)
+            persist: boolean, optional
+                Wheter to keep the log when finished, or empty the placeholder element.
+
+        """
+        self.placeholder = placeholder
+        self.persist = persist
+
+        self.logging_stream = _StreamlitLoggingStream(placeholder, accumulate)
+        self.handler = logging.StreamHandler(self.logging_stream)
+        self.logger = logging.getLogger(logger_name)
+
+    def __enter__(self):
+        self.logger.addHandler(self.handler)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.logger.removeHandler(self.handler)
+        if not self.persist:
+            self.placeholder.empty()
+
+
+class _StreamlitLoggingStream:
+    """Logging stream that writes logs to Streamlit front end."""
+
+    def __init__(self, placeholder, accumulate=True):
+        """
+        Logging stream that writes logs to Streamlit front end.
+
+        Parameters
+        ----------
+            placeholder: streamlit.empty
+                Streamlit placeholder object on which to write logs
+            accumulate: boolean, optional
+                Whether to accumulate log messages or to overwrite with each new
+                message, keeping only the last line (default: True)
+        """
+        self.placeholder = placeholder
+        self.accumulate = accumulate
+        self.message_list = []
+
+    def write(self, message):
+        if self.accumulate:
+            self.message_list.append(message)
+        else:
+            self.message_list = [message]
+        self.placeholder.info("\n".join(self.message_list))
+
+
+def zip_files(file_list):
+    bytesio = io.BytesIO()
+    with zipfile.ZipFile(bytesio, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for f in file_list:
+            zf.write(f, arcname=os.path.basename(f))
+
+    bytesio.seek(0)
+    return bytesio.read()
+
+
+def get_zipfile_href(file_list, filename="download.zip"):
+    zipf = zip_files(file_list)
+    b64 = base64.b64encode(zipf).decode()
+    href = f'<a href="data:file/zip;base64,{b64}" download="{filename}">Download results</a>'
+    return href

--- a/streamlit/streamlit_utils.py
+++ b/streamlit/streamlit_utils.py
@@ -8,13 +8,7 @@ import tempfile
 import zipfile
 from typing import BinaryIO
 
-
-def bytesio_to_tempfile(bytesio: BinaryIO) -> str:
-    """Write BytesIO object to temporary file."""
-    with tempfile.NamedTemporaryFile(delete=False) as tmp:
-        tmp.write(bytesio.getbuffer())
-        filepath = tmp.name
-    return filepath
+import streamlit as st
 
 
 class StreamlitLogger:
@@ -78,6 +72,23 @@ class _StreamlitLoggingStream:
         else:
             self.message_list = [message]
         self.placeholder.info("\n".join(self.message_list))
+
+
+def hide_streamlit_menu():
+    hide_menu_style = """
+    <style>
+    #MainMenu {visibility: hidden;}
+    </style>
+    """
+    st.markdown(hide_menu_style, unsafe_allow_html=True)
+
+
+def bytesio_to_tempfile(bytesio: BinaryIO) -> str:
+    """Write BytesIO object to temporary file."""
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        tmp.write(bytesio.getbuffer())
+        filepath = tmp.name
+    return filepath
 
 
 def zip_files(file_list):

--- a/streamlit/streamlit_utils.py
+++ b/streamlit/streamlit_utils.py
@@ -4,9 +4,13 @@ import base64
 import io
 import logging
 import os
+import re
 import tempfile
+import uuid
 import zipfile
 from typing import BinaryIO
+
+from typing_extensions import get_origin
 
 import streamlit as st
 
@@ -71,7 +75,7 @@ class _StreamlitLoggingStream:
             self.message_list.append(message)
         else:
             self.message_list = [message]
-        self.placeholder.info("\n".join(self.message_list))
+        self.placeholder.markdown("```\n" + "".join(self.message_list) + "\n```")
 
 
 def hide_streamlit_menu():
@@ -101,8 +105,76 @@ def zip_files(file_list):
     return bytesio.read()
 
 
-def get_zipfile_href(file_list, filename="download.zip"):
+def get_zipfile_href(file_list):
+    """Generate href for zip download of file list."""
     zipf = zip_files(file_list)
     b64 = base64.b64encode(zipf).decode()
-    href = f'<a href="data:file/zip;base64,{b64}" download="{filename}">Download results</a>'
+    href = f'data:file/zip;base64,{b64}'
     return href
+
+
+def encode_object_for_url(object_to_download):
+    try:
+        b64 = base64.b64encode(object_to_download.encode()).decode()
+    except AttributeError:
+        b64 = base64.b64encode(object_to_download).decode()
+    return b64
+
+
+def styled_download_button(
+    href, button_text, download_filename=None,
+):
+    """
+    Generates a styled button with any given href.
+
+    From: https://discuss.streamlit.io/t/a-download-button-with-custom-css/4220
+
+    Params
+    ------
+    href
+        Link to place in HTML `<a>` href field
+    button_text, str
+        Text to display on download button (e.g. 'click here to download file')
+    download_filename, str (optional)
+        If download is a file, add its filename and extension. e.g. mydata.csv,
+        some_txt_output.txt
+
+    """
+    button_uuid = str(uuid.uuid4()).replace("-", "")
+    button_id = re.sub(r"\d+", "", button_uuid)
+
+    custom_css = f"""
+        <style>
+            #{button_id} {{
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                background-color: {st.config.get_option("theme.backgroundColor")};
+                color: {st.config.get_option("theme.textColor")};
+                padding: .25rem .75rem;
+                position: relative;
+                text-decoration: none;
+                border-radius: 4px;
+                border-width: 1px;
+                border-style: solid;
+                border-color: rgb(230, 234, 241);
+                border-image: initial;
+            }}
+            #{button_id}:hover {{
+                border-color: {st.config.get_option("theme.primaryColor")};
+                color: {st.config.get_option("theme.primaryColor")};
+            }}
+            #{button_id}:active {{
+                box-shadow: none;
+                background-color: {st.config.get_option("theme.primaryColor")};
+                color: white;
+                }}
+        </style> """
+
+    dl_string = f'download="{download_filename}"' if download_filename else ''
+    dl_link = (
+        custom_css
+        + f'<a {dl_string} id="{button_id}" href="{href}">{button_text}</a><br><br>'
+    )
+
+    st.markdown(dl_link, unsafe_allow_html=True)


### PR DESCRIPTION
Add code and Dockerfile for a minimal Streamlit webserver. User can upload data, set configuration options, and download zipped results. Basic plots showing the results are still missing, but should be feasible to implement in the near future. 

On each GitHub release, a docker image is built and pushed to ghcr.io.