### PR TITLE
Allow long-form modification labels in MaxQuant parser

### DIFF
--- a/ms2rescore/_exceptions.py
+++ b/ms2rescore/_exceptions.py
@@ -11,3 +11,10 @@ class MS2RescoreConfigurationError(MS2RescoreError):
     """Invalid MS2Rescore configuration."""
 
     pass
+
+class IDFileParsingError(MS2RescoreError):
+    """Identification file parsing error."""
+
+class ModificationParsingError(IDFileParsingError):
+    """Identification file parsing error."""
+

--- a/ms2rescore/maxquant.py
+++ b/ms2rescore/maxquant.py
@@ -311,7 +311,7 @@ class MSMSAccessor:
         for seq, mod_seq in zip(
             self._obj["Sequence"].to_list(), mod_sequences.to_list()
         ):
-            peprec_mods.append(self._get_peprec_modification(
+            peprec_mods.append(self._get_single_peprec_modification(
                 seq, mod_seq, modification_mapping, fixed_modifications
             ))
         return peprec_mods

--- a/tests/test_maxquant.py
+++ b/tests/test_maxquant.py
@@ -15,7 +15,12 @@ class TestMSMS:
         "ac": "Acetyl",
         "cm": "Carbamidomethyl",
         "de": "Deamidated",
-        "gl": "Gln->pyro-Glu"
+        "gl": "Gln->pyro-Glu",
+        "Ox": "Oxidation",
+        "Oxidation (M)": "Oxidation",
+        "Acetyl (Protein N-term)": "Acetyl",
+        "Amidated (Peptide C-term)": "Amidated",
+        "Delta:H(4)C(3)": "Delta:H(4)C(3)"
     }
 
     def test_get_peprec_modifications(self):
@@ -30,6 +35,15 @@ class TestMSMS:
                 'VGVNGFGR',
                 'EEEIAALVIDNGSGMCK',
                 'SDKPDMAEIEK',
+                'YYWGGHYSWDMAK',
+                'YYWGGHYSWDMAK',
+                'YYWGGHYMWDMAK',
+                'DFKSK',
+                'ATGPMSFLK',
+                'ACDE',
+                'ACMDE',
+                'MACMDEM',
+                'DAAATGPSFWLGNETLK',
             ],
             "input_modified_sequence": [
                 '_VGVGFGR_',
@@ -40,6 +54,15 @@ class TestMSMS:
                 '_VGVN(de)GFGR_',
                 '_(ac)EEEIAALVIDNGSGM(ox)CK_',
                 '_(ac)SDKPDM(ox)AEIEK_',
+                '_YYWGGHYSWDM(Ox)AK_',
+                '_YYWGGHYSWDM(Oxidation (M))AK_',
+                '_YYWGGHYM(ox)WDM(ox)AK_',
+                '_DFK(Delta:H(4)C(3))SK_',
+                '_(Acetyl (Protein N-term))ATGPM(ox)SFLK_',
+                '_ACDE(Amidated (Peptide C-term))_',
+                '_ACM(Ox)DE(Amidated (Peptide C-term))_',
+                '_(Acetyl (Protein N-term))M(Ox)ACM(Ox)DEM(Ox)(Amidated (Peptide C-term))_',
+                '_D(Acetyl (Protein N-term))AAATGPSFWLGNETLK_',
             ],
             "expected_output": [
                 '-',
@@ -49,7 +72,16 @@ class TestMSMS:
                 '3|Oxidation',
                 '4|Deamidated',
                 '0|Acetyl|15|Oxidation|16|Carbamidomethyl',
-                '0|Acetyl|6|Oxidation'
+                '0|Acetyl|6|Oxidation',
+                '11|Oxidation',
+                '11|Oxidation',
+                '8|Oxidation|11|Oxidation',
+                '3|Delta:H(4)C(3)',
+                '0|Acetyl|5|Oxidation',
+                '2|Carbamidomethyl|-1|Amidated',
+                '2|Carbamidomethyl|3|Oxidation|-1|Amidated',
+                '0|Acetyl|1|Oxidation|3|Carbamidomethyl|4|Oxidation|7|Oxidation|-1|Amidated',
+                '1|Acetyl',
             ]
         }
 

--- a/tests/test_maxquant.py
+++ b/tests/test_maxquant.py
@@ -21,8 +21,19 @@ class TestMSMS:
     def test_get_peprec_modifications(self):
 
         test_cases = {
-            "input": [
+            "input_sequence": [
+                'VGVGFGR',
+                'MCK',
+                'EEEIAALVIDNGSGMCK',
+                'QYDADLEQILIQWITTQCRK',
+                'LAMQEFMILPVGAANFR',
+                'VGVNGFGR',
+                'EEEIAALVIDNGSGMCK',
+                'SDKPDMAEIEK',
+            ],
+            "input_modified_sequence": [
                 '_VGVGFGR_',
+                '_MCK_',
                 '_(ac)EEEIAALVIDNGSGMCK_',
                 '_(gl)QYDADLEQILIQWITTQCRK_',
                 '_LAM(ox)QEFMILPVGAANFR_',
@@ -32,6 +43,7 @@ class TestMSMS:
             ],
             "expected_output": [
                 '-',
+                '2|Carbamidomethyl',
                 '0|Acetyl|16|Carbamidomethyl',
                 '0|Gln->pyro-Glu|18|Carbamidomethyl',
                 '3|Oxidation',
@@ -42,12 +54,12 @@ class TestMSMS:
         }
 
         df = pd.DataFrame({
-            "Modified sequence": test_cases["input"],
-            "Mass error [Da]": [''] * len(test_cases["input"])
+            "Sequence": test_cases["input_sequence"],
+            "Modified sequence": test_cases["input_modified_sequence"],
+            "Mass error [Da]": [''] * len(test_cases["input_sequence"])
         })
 
-        observed_output = df.msms._get_peprec_modifications(
-            df["Modified sequence"],
+        observed_output = df.msms.get_peprec_modifications(
             modification_mapping=self.modification_mapping,
             fixed_modifications=self.fixed_modifications
         )


### PR DESCRIPTION
## Fixes
- Refactored parsing of MaxQuant `Modified sequence` to allow for new long form modification labels (e.g. `PEPM(Oxidation (M)K` instead of `PEPM(ox)K`)
  - Fixes #41 
