### PR TITLE
Minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,10 @@ To install a newer version of MS²Rescore, run `upgrade-gui-windows.bat`.
 
 ### GUI
 
-Run `start-gui-windows.bat` or run `python -m ms2rescore.gui` in your terminal to start
-the graphical user interface. Most common settings can be configured through the UI.
-For some advanced settings, see [Configuration file](#configuration-file).
+Run `start-gui-windows.bat` or run `ms2rescore-gui` or
+`python -m ms2rescore.gui`in your terminal to start the graphical user
+interface. Most common settings can be configured through the
+UI. For some advanced settings, see [Configuration file](#configuration-file).
 
 <img src="img/gui-screenshot.png" height=480 />
 

--- a/ms2rescore/gui.py
+++ b/ms2rescore/gui.py
@@ -2,24 +2,21 @@
 
 import argparse
 import ast
-from distutils.command.config import config
-from email.policy import default
+import importlib.resources as pkg_resources
 import json
 import logging
-import pprint
 import multiprocessing
+import pprint
+import sys
+import warnings
 from pathlib import Path
 
 from gooey import Gooey, GooeyParser, local_resource_path
 from ms2pip.ms2pipC import MODELS as ms2pip_models
-from ms2rescore import MS2ReScore, package_data
-import ms2rescore.package_data.img as img_module
-from ms2rescore._exceptions import MS2RescoreError
 
-try:
-    import importlib.resources as pkg_resources
-except ImportError:
-    import importlib_resources as pkg_resources
+from ms2rescore import MS2ReScore, package_data
+from ms2rescore._exceptions import MS2RescoreError
+import ms2rescore.package_data.img as img_module
 
 
 logger = logging.getLogger(__name__)
@@ -42,9 +39,15 @@ class MS2RescoreGUIError(MS2RescoreError):
     tabbed_groups=True,
     requires_shell=False,
     default_size=(760, 720),
+    target=None if getattr(sys, 'frozen', False) else "ms2rescore-gui"
 )
 def main():
     """Run MS²Rescore."""
+    # Disable warnings in GUI
+    warnings.filterwarnings('ignore', category=DeprecationWarning)
+    warnings.filterwarnings('ignore', category=FutureWarning)
+    warnings.filterwarnings('ignore', category=UserWarning)
+
     conf = _parse_arguments().__dict__
     conf = parse_settings(conf)
     rescore = MS2ReScore(parse_cli_args=False, configuration=conf, set_logger=True)

--- a/ms2rescore/percolator.py
+++ b/ms2rescore/percolator.py
@@ -151,7 +151,7 @@ class PercolatorIn:
         """Infer modification label style (e.g. unimod_accession or mass shift)."""
         # TODO: What happens if there are no mods? Crashes?
         modified_peptides = self.df[
-            self.df["Peptide"].str.contains(r"\[([^\[^\]]*)\]", regex=True)
+            self.df["Peptide"].str.contains(r"\[[^\[^\]]*\]", regex=True)
         ]["Peptide"]
         if (
             modified_peptides.str.extract(r"\[([^\[^\]]*)\]", expand=False)

--- a/setup.py
+++ b/setup.py
@@ -57,13 +57,13 @@ setup(
     include_package_data=True,
     entry_points={"console_scripts": [
         "ms2rescore=ms2rescore.__main__:main",
+        "ms2rescore-gui=ms2rescore.gui:main",
     ]},
     python_requires=">=3.7",
     install_requires=[
-        "importlib-resources;python_version<'3.7'",
         "numpy>=1.16.0,<2",
         "pandas>=0.24.0,<2",
-        "scikit-learn>=0.20.0,<1",
+        "scikit-learn>=0.20.0,<2",
         "scipy>=1.2.0,<2",
         "tqdm>=4.31.0,<5",
         "pyteomics>=4.1.0,<5",


### PR DESCRIPTION
## Refactoring and minor changes

- Ignore Deprecation-/Future-/UserWarnings in GUI mode (fixes https://github.com/compomics/ms2rescore/issues/61)
- Cleanup imports and remove importlib_resources backport (Python 3.6 compatibility not needed anymore)
- Set Gooey target to allow gui startup from `ms2rescore-gui` entrypoint and add `ms2rescore-gui` entrypoint (GUI can now be started from the terminal with both `python -m ms2rescore.gui` and `ms2rescore-gui`).
- Relax scikit-learn dependency to <2 (v1.0.0 now released)
- Fix UserWarning in `percolator.py` (unused groups in regex for Pandas `str.match()`)