### PR TITLE
Rich CLI output; Percolator changes; minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,10 @@ run, the following output files can be expected:
 
 For each feature set combination (e.g. [`rt`, `ms2pip`, `searchengine`]):
 - `<file>.pin` Percolator IN file
-- `<file>.pout` Percolator OUT file with target PSMs
-- `<file>.pout_dec` Percolator OUT file with decoy PSMs
+- `<file>_target_psms.pout` Percolator OUT file with target PSMs
+- `<file>_decoy_psms.pout` Percolator OUT file with decoy PSMs
+- `<file>_target_peptides.pout` Percolator OUT file with target peptides
+- `<file>_decoy_peptides.pout` Percolator OUT file with decoy peptides
 - `<file>.weights` Internal feature weights used by Percolator's scoring function.
 
 ---

--- a/ms2rescore/__init__.py
+++ b/ms2rescore/__init__.py
@@ -41,6 +41,7 @@ class MS2ReScore:
         parse_cli_args: bool = True,
         configuration: Optional[Dict] = None,
         set_logger: bool = False,
+        rich_console: Optional[Console] = None,
     ) -> None:
         """Initialize MS2ReScore object."""
         self.config = parse_config(
@@ -48,16 +49,18 @@ class MS2ReScore:
         )
         self.log_level = self.config["general"]["log_level"]
 
-        if set_logger:
+        if rich_console:
+            self._rich_console = rich_console
+        else:
             self._rich_console = Console(record=True)
+
+        if set_logger:
             setup_logging.setup_logging(
                 self.log_level,
                 log_file=self.config["general"]["output_filename"]
                 + "_ms2rescore_log.txt",
                 rich_console=self._rich_console,
             )
-        else:
-            self._rich_console = None
 
         if self.config["general"]["run_percolator"]:
             self._validate_cli_dependency("percolator -h")

--- a/ms2rescore/__init__.py
+++ b/ms2rescore/__init__.py
@@ -8,9 +8,9 @@ import tempfile
 from multiprocessing import cpu_count
 from typing import Dict, Optional, Union
 
-from pandas.errors import EmptyDataError
-
 from ms2pip.ms2pipC import MS2PIP
+from pandas.errors import EmptyDataError
+from rich.console import Console
 
 from ms2rescore import id_file_parser, plotting, rescore_core, setup_logging
 from ms2rescore._exceptions import MS2RescoreError
@@ -46,9 +46,18 @@ class MS2ReScore:
         self.config = parse_config(
             parse_cli_args=parse_cli_args, config_class=configuration
         )
+        self.log_level = self.config["general"]["log_level"]
 
         if set_logger:
-            setup_logging.setup_logging(self.config["general"]["log_level"])
+            self._rich_console = Console(record=True)
+            setup_logging.setup_logging(
+                self.log_level,
+                log_file=self.config["general"]["output_filename"]
+                + "_ms2rescore_log.txt",
+                rich_console=self._rich_console,
+            )
+        else:
+            self._rich_console = None
 
         if self.config["general"]["run_percolator"]:
             self._validate_cli_dependency("percolator -h")
@@ -171,7 +180,7 @@ class MS2ReScore:
             preds_filename,
             output_filename + "_ms2pipfeatures.csv",
             num_cpu,
-            show_progress_bar=False,
+            show_progress_bar=True,
         )
 
     @staticmethod
@@ -187,13 +196,20 @@ class MS2ReScore:
             output_filename + "_rtfeatures.csv",
             num_cpu=num_cpu,
             higher_psm_score_better=True,
-            calibration_set_size=250
+            calibration_set_size=250,
         )
         rt_int.run()
 
     def _run_percolator(self):
         """Run Percolator with different feature subsets."""
 
+        log_level_map = {
+            "critical": 0,
+            "error": 0,
+            "warning": 0,
+            "info": 1,
+            "debug": 2,
+        }
 
         for subset in self.config["general"]["feature_sets"]:
             subname = (
@@ -204,31 +220,34 @@ class MS2ReScore:
             )
 
             kwargs = {
-                    "results-psms": subname + ".pout",
-                    "decoy-results-psms": subname + ".pout_dec",
-                    "weights": subname + ".weights",
-                    "verbose": 0,
-                    "post-processing-tdc": True
-                    }
+                "results-psms": subname + "_target_psms.pout",
+                "decoy-results-psms": subname + "_decoy_psms.pout",
+                "results-peptides": subname + "_target_peptides.pout",
+                "decoy-results-peptides": subname + "_decoy_peptides.pout",
+                "weights": subname + ".weights",
+                "verbose": log_level_map[self.log_level],
+                "post-processing-tdc": True,
+            }
             kwargs.update(self.config["percolator"])
 
             percolator_cmd = ["percolator"]
             for key, value in kwargs.items():
 
-                if not isinstance(value,bool):
+                if not isinstance(value, bool):
                     percolator_cmd.append(f"--{key}")
                     percolator_cmd.append(str(value))
-                elif isinstance(value, bool) & value==False:
+                elif isinstance(value, bool) & value == False:
                     continue
                 else:
                     percolator_cmd.append(f"--{key}")
-            percolator_cmd.append(subname+".pin")
+            percolator_cmd.append(subname + ".pin")
+
             logger.info("Running Percolator: %s", " ".join(percolator_cmd))
             output = subprocess.run(percolator_cmd, capture_output=True, check=True)
-
-            logger.debug(output.stdout)
-            logger.info(output.stderr)
-
+            logger.info(
+                "Percolator output: \n" + output.stderr.decode(encoding="utf-8"),
+                extra={"highlighter": None},
+            )
 
     def run(self):
         """Run MS²ReScore."""
@@ -276,9 +295,7 @@ class MS2ReScore:
             if self.config["general"]["plotting"]:
                 logger.info("Generating Rescore plots")
 
-                plotting.PIN(
-                    peprec_filename, self.config["general"]["output_filename"]
-                )
+                plotting.PIN(peprec_filename, self.config["general"]["output_filename"])
 
                 for fset in self.config["general"]["feature_sets"]:
                     pout_file = (
@@ -298,16 +315,30 @@ class MS2ReScore:
                             pout_file,
                             pout_decoy_file,
                             self.config["general"]["output_filename"],
-                            " ".join(fset)
+                            " ".join(fset),
                         )
                     except EmptyDataError:
-                        logger.warn(f"Feature set: {'_'.join(fset)} returned empty pout file")
+                        logger.warn(
+                            f"Feature set: {'_'.join(fset)} returned empty pout file"
+                        )
                         continue
 
                 plotting.RescoreRecord.save_plots_to_pdf(
                     self.config["general"]["output_filename"] + "_plots.pdf",
                     FDR_thresholds=[0.01, 0.001],
                 )
-        if not self.config["general"]["run_percolator"] and self.config["general"]["plotting"]:
+        if (
+            not self.config["general"]["run_percolator"]
+            and self.config["general"]["plotting"]
+        ):
             logger.warn("To plot rescore results run_percolator should be enabled")
         logger.info("MS²ReScore finished!")
+
+    def save_log(self) -> None:
+        """Save full rich-text log to HTML."""
+        if self._rich_console:
+            self._rich_console.save_html(
+                self.config["general"]["output_filename"] + "_ms2rescore_log.html"
+            )
+        else:
+            logger.warning("Could not write logs to HTML: rich console is not defined.")

--- a/ms2rescore/__main__.py
+++ b/ms2rescore/__main__.py
@@ -4,17 +4,20 @@ import logging
 
 from ms2rescore import MS2ReScore
 
-
 logger = logging.getLogger(__name__)
 
 
 def main():
     """Run MS²ReScore."""
+    rescore = None
     try:
         rescore = MS2ReScore(parse_cli_args=True, configuration=None, set_logger=True)
         rescore.run()
     except Exception:
-        logger.exception("Critical error occured in MS2ReScore")
+        logger.exception("Critical error occured in MS²Rescore")
+    finally:
+        if rescore:
+            rescore.save_log()
 
 
 if __name__ == "__main__":

--- a/ms2rescore/config_parser.py
+++ b/ms2rescore/config_parser.py
@@ -54,7 +54,7 @@ def _parse_arguments() -> argparse.Namespace:
         action="store",
         type=str,
         dest="tmp_path",
-        help="path to directory to place temporary files"
+        help="path to directory to place temporary files",
     )
     parser.add_argument(
         "-o",
@@ -70,7 +70,6 @@ def _parse_arguments() -> argparse.Namespace:
         action="store",
         type=str,
         dest="log_level",
-        default="info",
         help="logging level (default: `info`)",
     )
     parser.add_argument(
@@ -146,7 +145,9 @@ def _validate_num_cpu(config: Dict) -> Dict:
     return config
 
 
-def parse_config(parse_cli_args: bool = True, config_class: Optional[Dict] = None) -> Dict:
+def parse_config(
+    parse_cli_args: bool = True, config_class: Optional[Dict] = None
+) -> Dict:
     """
     Parse and validate MS²ReScore configuration files and arguments.
 
@@ -196,7 +197,9 @@ def parse_config(parse_cli_args: bool = True, config_class: Optional[Dict] = Non
     config["general"]["pipeline"] = config["general"]["pipeline"].lower()
 
     try:
-        config["maxquant_to_rescore"]["mgf_title_pattern"] = re.compile(config["maxquant_to_rescore"]["mgf_title_pattern"])
+        config["maxquant_to_rescore"]["mgf_title_pattern"] = re.compile(
+            config["maxquant_to_rescore"]["mgf_title_pattern"]
+        )
     except re.error:
         raise MS2RescoreConfigurationError(
             "Invalid regex pattern, please provide valid regex patttern"

--- a/ms2rescore/gui.py
+++ b/ms2rescore/gui.py
@@ -11,14 +11,23 @@ import sys
 import warnings
 from pathlib import Path
 
-from gooey import Gooey, GooeyParser, local_resource_path
 from ms2pip.ms2pipC import MODELS as ms2pip_models
+from rich.console import Console
 
 import ms2rescore.package_data.img as img_module
 from ms2rescore import MS2ReScore, package_data
 from ms2rescore._exceptions import MS2RescoreError
 
 logger = logging.getLogger(__name__)
+
+try:
+    from gooey import Gooey, GooeyParser, local_resource_path
+except:
+    logger.critical(
+        "The `gooey` package could not be imported. Please install MS²Rescore with the "
+        "additional `gui` dependencies: `pip install ms2rescore[gui]`."
+    )
+    sys.exit()
 
 # Get path to package_data/images
 # Workaround with parent of specific file required for Python 3.9+ support
@@ -39,6 +48,7 @@ class MS2RescoreGUIError(MS2RescoreError):
     requires_shell=False,
     default_size=(760, 720),
     target=None if getattr(sys, "frozen", False) else "ms2rescore-gui",
+    monospace_display=True,
 )
 def main():
     """Run MS²Rescore."""
@@ -49,10 +59,12 @@ def main():
 
     conf = _parse_arguments().__dict__
     conf = parse_settings(conf)
+    rich_console = Console(width=98, record=True)
     rescore = MS2ReScore(
         parse_cli_args=False,
         configuration=conf,
         set_logger=True,
+        rich_console=rich_console,
     )
     rescore.run()
     rescore.save_log()

--- a/ms2rescore/gui.py
+++ b/ms2rescore/gui.py
@@ -52,6 +52,7 @@ def main():
     conf = parse_settings(conf)
     rescore = MS2ReScore(parse_cli_args=False, configuration=conf, set_logger=True)
     rescore.run()
+    rescore.save_log()
 
 
 def _parse_arguments() -> argparse.Namespace:

--- a/ms2rescore/gui.py
+++ b/ms2rescore/gui.py
@@ -14,10 +14,9 @@ from pathlib import Path
 from gooey import Gooey, GooeyParser, local_resource_path
 from ms2pip.ms2pipC import MODELS as ms2pip_models
 
+import ms2rescore.package_data.img as img_module
 from ms2rescore import MS2ReScore, package_data
 from ms2rescore._exceptions import MS2RescoreError
-import ms2rescore.package_data.img as img_module
-
 
 logger = logging.getLogger(__name__)
 
@@ -39,36 +38,44 @@ class MS2RescoreGUIError(MS2RescoreError):
     tabbed_groups=True,
     requires_shell=False,
     default_size=(760, 720),
-    target=None if getattr(sys, 'frozen', False) else "ms2rescore-gui"
+    target=None if getattr(sys, "frozen", False) else "ms2rescore-gui",
 )
 def main():
     """Run MS²Rescore."""
     # Disable warnings in GUI
-    warnings.filterwarnings('ignore', category=DeprecationWarning)
-    warnings.filterwarnings('ignore', category=FutureWarning)
-    warnings.filterwarnings('ignore', category=UserWarning)
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    warnings.filterwarnings("ignore", category=FutureWarning)
+    warnings.filterwarnings("ignore", category=UserWarning)
 
     conf = _parse_arguments().__dict__
     conf = parse_settings(conf)
-    rescore = MS2ReScore(parse_cli_args=False, configuration=conf, set_logger=True)
+    rescore = MS2ReScore(
+        parse_cli_args=False,
+        configuration=conf,
+        set_logger=True,
+    )
     rescore.run()
     rescore.save_log()
 
 
 def _parse_arguments() -> argparse.Namespace:
     """Parse GUI arguments."""
-    default_config = json.load(pkg_resources.open_text(package_data, "config_default.json"))
+    default_config = json.load(
+        pkg_resources.open_text(package_data, "config_default.json")
+    )
     ms2pip_mods = default_config["ms2pip"]["modifications"]
 
     parser = GooeyParser()
-    general = parser.add_argument_group("General configuration",gooey_options={'columns':2})
+    general = parser.add_argument_group(
+        "General configuration", gooey_options={"columns": 2}
+    )
     general.add_argument(
         "identification_file",
         metavar="Identification file (required)",
         type=str,
         help="Path to identification file (pin, mzid, msms.txt, tandem xml...)",
         widget="FileChooser",
-        gooey_options={"full_width":True}
+        gooey_options={"full_width": True},
     )
     general.add_argument(
         "-m",
@@ -121,7 +128,15 @@ def _parse_arguments() -> argparse.Namespace:
         ),
         widget="Dropdown",
         default="infer",
-        choices=["infer", "pin","maxquant", "msgfplus", "tandem", "peptideshaker", "peaks"]
+        choices=[
+            "infer",
+            "pin",
+            "maxquant",
+            "msgfplus",
+            "tandem",
+            "peptideshaker",
+            "peaks",
+        ],
     )
     general.add_argument(
         "-l",
@@ -149,8 +164,8 @@ def _parse_arguments() -> argparse.Namespace:
             "ms2pip rt",
             "searchengine",
             "ms2pip",
-            "rt"
-        ]
+            "rt",
+        ],
     )
 
     general.add_argument(
@@ -162,12 +177,8 @@ def _parse_arguments() -> argparse.Namespace:
         default=-1,
         help="Number of parallel processes to use; -1 for all available",
         widget="IntegerField",
-        gooey_options={
-            'min': -1,
-            'max': multiprocessing.cpu_count()
-        }
+        gooey_options={"min": -1, "max": multiprocessing.cpu_count()},
     )
-
 
     maxquant_settings = parser.add_argument_group(
         "MaxQuant settings",
@@ -177,7 +188,7 @@ def _parse_arguments() -> argparse.Namespace:
             "correctly parse the msms.txt file, additional modification information "
             "needs to be provided below. Make sure MaxQuant was run without "
             "PSM-level FDR filtering; i.e. the FDR Threshold set at 1."
-        )
+        ),
     )
     maxquant_settings.add_argument(
         "--regex_pattern",
@@ -187,15 +198,12 @@ def _parse_arguments() -> argparse.Namespace:
         type=str,
         default="TITLE=.*scan=([0-9]+).*$",
         widget="Textarea",
-        gooey_options={
-            "height":27,
-            "full_width":True
-            },
+        gooey_options={"height": 27, "full_width": True},
         help=(
             "Regex pattern to extract index number from MGF TITLE field. "
-            "Default: \'TITLE=.*scan=([0-9]+).*$\' (ThermoRawFileParsed MGF files)\n"
-            "Example: \'TITLE=([0-9]+).*$\' (index number immediately after TITLE field)"
-        )
+            "Default: 'TITLE=.*scan=([0-9]+).*$' (ThermoRawFileParsed MGF files)\n"
+            "Example: 'TITLE=([0-9]+).*$' (index number immediately after TITLE field)"
+        ),
     )
 
     maxquant_settings.add_argument(
@@ -211,9 +219,7 @@ def _parse_arguments() -> argparse.Namespace:
             "<full modification name>, one per line, space-separated."
         ),
         widget="Textarea",
-        gooey_options={
-            "height":120
-            }
+        gooey_options={"height": 120},
     )
     maxquant_settings.add_argument(
         "--modification_mapping",
@@ -231,14 +237,10 @@ def _parse_arguments() -> argparse.Namespace:
             "space-separated."
         ),
         widget="Textarea",
-        gooey_options={
-            "height": 120
-        },
+        gooey_options={"height": 120},
     )
 
-    ms2pip_settings = parser.add_argument_group(
-        "MS²PIP settings"
-    )
+    ms2pip_settings = parser.add_argument_group("MS²PIP settings")
     ms2pip_settings.add_argument(
         "--ms2pip_model",
         metavar="MS²PIP model",
@@ -270,25 +272,25 @@ def _parse_arguments() -> argparse.Namespace:
             "documentation for more info."
         ),
         widget="Textarea",
-        gooey_options={
-            "full_width":True,
-            "height": 240
-        },
+        gooey_options={"full_width": True, "height": 240},
     )
 
     return parser.parse_args()
 
-def parse_settings(config:dict) -> dict:
+
+def parse_settings(config: dict) -> dict:
     "Parse non-general settings into one dict"
 
     parsed_config = {
-        "general" : config,
+        "general": config,
         "maxquant_to_rescore": {},
         "ms2pip": {},
     }
 
     # general configuration
-    parsed_config["general"]["feature_sets"] = [parsed_config["general"]["feature_sets"].split(" ")]
+    parsed_config["general"]["feature_sets"] = [
+        parsed_config["general"]["feature_sets"].split(" ")
+    ]
     # MaxQuant configuration
     for conf_item in ["modification_mapping", "fixed_modifications"]:
         parsed_conf_item = parsed_config["general"].pop(conf_item)
@@ -304,7 +306,9 @@ def parse_settings(config:dict) -> dict:
                 "Invalid MaxQuant modification configuration. Make sure that the "
                 "modification configuration fields are formatted correctly."
             )
-    parsed_config["maxquant_to_rescore"]["mgf_title_pattern"] = parsed_config["general"].pop("mgf_title_pattern")
+    parsed_config["maxquant_to_rescore"]["mgf_title_pattern"] = parsed_config[
+        "general"
+    ].pop("mgf_title_pattern")
 
     # MS²PIP configuration
     parsed_config["ms2pip"] = {
@@ -313,7 +317,7 @@ def parse_settings(config:dict) -> dict:
     }
 
     try:
-        parsed_config["ms2pip"]["modifications"] =  ast.literal_eval(
+        parsed_config["ms2pip"]["modifications"] = ast.literal_eval(
             parsed_config["general"].pop("ms2pip_modifications")
         )
     except Exception:

--- a/ms2rescore/parse_mgf.py
+++ b/ms2rescore/parse_mgf.py
@@ -3,9 +3,10 @@
 import logging
 import mmap
 import os.path
-import re
 import random
-from tqdm import tqdm
+import re
+
+from rich.progress import track
 
 from ms2rescore._exceptions import MS2RescoreError
 
@@ -94,8 +95,12 @@ def parse_mgf(df_in, mgf_folder, mgf_title_pattern=None, outname='scan_mgf_resul
 
     with open(outname, 'w') as out:
         count = 0
-        iterator = tqdm(runs) if show_progress_bar else runs
-        for run in iterator:
+        for run in track(
+            runs,
+            description="Parsing MGF file",
+            disable=True if not show_progress_bar else False,
+            transient=True
+        ):
             current_mgf_file = os.path.join(mgf_folder, run + file_suffix)
             spec_set = set(df_in[(df_in[filename_col] == run)][spec_title_col].values)
             # Temporary fix: replace charges in MGF with ID'ed charges

--- a/ms2rescore/setup_logging.py
+++ b/ms2rescore/setup_logging.py
@@ -1,24 +1,39 @@
 import logging
+from logging import FileHandler
+from pathlib import Path
+from typing import Union
+
+from rich.console import Console
+from rich.logging import RichHandler
 
 
-def setup_logging(passed_level):
+def setup_logging(
+    passed_level: str, log_file: Union[str, Path], rich_console: Console = None
+):
     log_mapping = {
-        'critical': logging.CRITICAL,
-        'error': logging.ERROR,
-        'warning': logging.WARNING,
-        'info': logging.INFO,
-        'debug': logging.DEBUG,
+        "critical": logging.CRITICAL,
+        "error": logging.ERROR,
+        "warning": logging.WARNING,
+        "info": logging.INFO,
+        "debug": logging.DEBUG,
     }
 
     if passed_level not in log_mapping:
         print(
             "Invalid log level. Should be one of the following: ",
-            ', '.join(log_mapping.keys())
+            ", ".join(log_mapping.keys()),
         )
         exit(1)
 
+    if not rich_console:
+        rich_console = Console(record=True)
+
     logging.basicConfig(
-        format='%(asctime)s // %(levelname)s // %(name)s // %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S',
-        level=log_mapping[passed_level]
+        format="%(name)s // %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        level=log_mapping[passed_level],
+        handlers=[
+            FileHandler(log_file, mode="w"),
+            RichHandler(rich_tracebacks=True, console=rich_console, show_path=False),
+        ],
     )

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
         "pandas>=0.24.0,<2",
         "scikit-learn>=0.20.0,<2",
         "scipy>=1.2.0,<2",
-        "tqdm>=4.31.0,<5",
+        "rich>=12",
         "pyteomics>=4.1.0,<5",
         "lxml>=4.5,<5",
         "ms2pip>=3.8,<4",

--- a/setup.py
+++ b/setup.py
@@ -37,10 +37,10 @@ setup(
     classifiers=[
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: Apache Software License",
-        "Operating System :: POSIX :: Linux",
+        "Operating System :: OS Independent",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Scientific/Engineering :: Bio-Informatics",
-        "Development Status :: 4 - Beta",
+        "Development Status :: 5 - Production/Stable",
     ],
     keywords=[
         "MS2Rescore",
@@ -55,10 +55,12 @@ setup(
     ],
     packages=["ms2rescore"],
     include_package_data=True,
-    entry_points={"console_scripts": [
-        "ms2rescore=ms2rescore.__main__:main",
-        "ms2rescore-gui=ms2rescore.gui:main",
-    ]},
+    entry_points={
+        "console_scripts": [
+            "ms2rescore=ms2rescore.__main__:main",
+            "ms2rescore-gui=ms2rescore.gui:main",
+        ]
+    },
     python_requires=">=3.7",
     install_requires=[
         "numpy>=1.16.0,<2",
@@ -69,7 +71,7 @@ setup(
         "pyteomics>=4.1.0,<5",
         "lxml>=4.5,<5",
         "ms2pip>=3.8,<4",
-        "click>=7,<8",
+        "click>=7",
         "cascade-config>=0.3.0,<2",
         "matplotlib>=3,<4",
         "seaborn>=0.11",


### PR DESCRIPTION
## Breaking changes ⚠️
- For improved clarity, Percolator output filenames have been changed:
  - `*.pout` -> `*_target_psms.pout`
  - `*.pout_dec` -> `*_decoy_psms.pout`

## Improvements 🚀
- Rich CLI output:
  - Use rich for better-formatted log messages
  - Use rich.progress.track instead of tqdm
- MS²Rescore now writes the log to a plain text and a formatted HTML file.
- Logged Percolator output now depends on the ms2rescore log level
- Peptide-level Percolator output files are now also returned: `*_target_peptides.pout` and `*_decoy_peptides.pout`
  
## Bugfixes 🪲
- Removed default value for `log_level` from argument parser, as it always overrode the
lower-hierarchy configurations (e.g. configuration file).

## Refactoring and minor changes 🔧
- Relaxed click version requirement from `>=7,<8` to `>=7`
- Fixed PyPI trove classifiers in readme (was still `Beta` and `Linux`)
- Applied black to changed files
