### PR TITLE
Fix gui maxquant modification parsing error

### DIFF
--- a/ms2rescore/gui.py
+++ b/ms2rescore/gui.py
@@ -294,7 +294,7 @@ def parse_settings(config:dict) -> dict:
         try:
             if parsed_conf_item:
                 parsed_conf_item = parsed_conf_item.split("\n")
-                parsed_conf_item = dict([tuple(x.split(" ")) for x in parsed_conf_item])
+                parsed_conf_item = dict([tuple(x.rsplit(" ",1)) for x in parsed_conf_item])
             else:
                 parsed_conf_item = {}
             parsed_config["maxquant_to_rescore"][conf_item] = parsed_conf_item


### PR DESCRIPTION
Fixed the parsing of the more recent modification names of Maxquant to allow for space to be in the name.