### PR TITLE
Fix build of Windows PyInstaller

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,7 +56,7 @@ jobs:
           pip install . pyinstaller
 
       - name: Install Inno Setup
-        uses: crazy-max/ghaction-chocolatey@v1
+        uses: crazy-max/ghaction-chocolatey@v3
         with:
           args: install innosetup -y --allow-unofficial --force
 
@@ -67,7 +67,7 @@ jobs:
         run: dist/ms2rescore/ms2rescore.exe
 
       - name: Run Inno Setup
-        run: ISCC.exe ./ms2rescore_innosetup.iss /DMyAppVersion=${{  github.ref_name }}
+        run: ISCC.exe ./ms2rescore_innosetup.iss /DAppVersion=${{  github.ref_name }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 jobs:
   python-package:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test-python-package:

--- a/ms2rescore.spec
+++ b/ms2rescore.spec
@@ -27,7 +27,8 @@ requirements = {
     for req in requirements
     if "; extra ==" not in req  # Exclude optional dependencies
 }
-requirements.update([project])
+requirements.update([project, "xgboost"])
+
 hidden_imports = set()
 datas = []
 binaries = []

--- a/ms2rescore_innosetup.iss
+++ b/ms2rescore_innosetup.iss
@@ -1,23 +1,23 @@
-#define MyAppName "MS2Rescore"
-#define MyAppPublisher "CompOmics"
-#define MyAppURL "https://github.com/compomics/ms2rescore"
-#define MyAppExeName "ms2rescore.exe"
+#define AppName "MS2Rescore"
+#define AppPublisher "CompOmics"
+#define AppURL "https://github.com/compomics/ms2rescore"
+#define AppExeName "ms2rescore.exe"
 
 [Setup]
-AppId={{2D3D12BD-3AE2-426E-8DE8-092148C12071}
-AppName={#MyAppName}
-AppVersion={#MyAppVersion}
-AppPublisher={#MyAppPublisher}
-AppPublisherURL={#MyAppURL}
-AppSupportURL={#MyAppURL}
-AppUpdatesURL={#MyAppURL}
-DefaultDirName={autopf}\{#MyAppName}
+AppId={2D3D12BD-3AE2-426E-8DE8-092148C12071}
+AppName={#AppName}
+AppVersion={#AppVersion}
+AppPublisher={#AppPublisher}
+AppPublisherURL={#AppURL}
+AppSupportURL={#AppURL}
+AppUpdatesURL={#AppURL}
+DefaultDirName={autopf}\{#AppName}
 DisableProgramGroupPage=yes
 LicenseFile=.\LICENSE
 PrivilegesRequired=lowest
 PrivilegesRequiredOverridesAllowed=dialog
 OutputDir="dist"
-OutputBaseFilename="{#MyAppName}-{#MyAppVersion}-Windows64bit"
+OutputBaseFilename="{#AppName}-{#AppVersion}-Windows64bit"
 Compression=lzma
 SolidCompression=yes
 WizardStyle=modern
@@ -32,8 +32,8 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 Source: "dist\ms2rescore\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Icons]
-Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
-Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+Name: "{autoprograms}\{#AppName}"; Filename: "{app}\{#AppExeName}"
+Name: "{autodesktop}\{#AppName}"; Filename: "{app}\{#AppExeName}"; Tasks: desktopicon
 
 [Run]
-Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
+Filename: "{app}\{#AppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(AppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
Fixes missing XGBoost dependency in frozen install (#101). Hardcoded as dependency in the pyinstaller spec for now. No idea why this is not added automatically. 