### PR TITLE
Fix GUI on Linux systems

### DIFF
--- a/ms2rescore/gui/app.py
+++ b/ms2rescore/gui/app.py
@@ -8,6 +8,7 @@ import sys
 import webbrowser
 from pathlib import Path
 from typing import Dict, List, Tuple
+import platform
 
 import customtkinter as ctk
 from joblib import parallel_backend
@@ -648,6 +649,7 @@ def app():
     dpi = root.winfo_fpixels("1i")
     root.geometry(f"{int(15*dpi)}x{int(10*dpi)}")
     root.title("MS²Rescore")
-    root.wm_iconbitmap(os.path.join(str(_IMG_DIR), "program_icon.ico"))
+    if platform.system() != "Linux":
+        root.wm_iconbitmap(os.path.join(str(_IMG_DIR), "program_icon.png"))
 
     root.mainloop()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ classifiers = [
 dynamic = ["version"]
 requires-python = ">=3.8"
 dependencies = [
-    "numpy>=1.16.0",
+    "numpy>=1.16.0; python_version != '3.11'",
+    "numpy==1.24.3; python_version == '3.11'",  # Incompatibility with sklearn, pygam, and TF...
     "pandas>=1.0",
     "rich>=12",
     "pyteomics>=4.1.0",


### PR DESCRIPTION
## Fixed

- Don't use unsupported icon on Linux systems (fixes #118)
- Pin Numpy version for Python 3.11 (incompatibility between pyGAM, sklearn, and tensorflow)
