### PR TITLE
Docs: Add instructions for fixed terminal modifications

### DIFF
--- a/docs/source/userguide/configuration.rst
+++ b/docs/source/userguide/configuration.rst
@@ -123,7 +123,7 @@ be configured separately. For instance:
   .. code-block:: json
 
     "fixed_modifications": {
-      "C": "U:Carbamidomethyl"
+      "U:Carbamidomethyl": ["C"]
     }
 
 .. tab:: TOML
@@ -131,13 +131,35 @@ be configured separately. For instance:
     .. code-block:: toml
 
       [ms2rescore.fixed_modifications]
-      "Carbamidomethyl" = ["C"]
+      "U:Carbamidomethyl" = ["C"]
 
 .. tab:: GUI
 
   .. figure:: ../_static/img/gui-fixed-modifications.png
     :width: 500px
     :alt: fixed modifications configuration in GUI
+
+
+Fixed terminal modifications can be added by using the special labels ``N-term`` and ``C-term``.
+For example, to additionally add TMT6plex to the N-terminus and lysine residues, the following
+configuration can be used:
+
+.. tab:: JSON
+
+  .. code-block:: json
+
+    "fixed_modifications": {
+      "U:Carbamidomethyl": ["C"],
+      "U:TMT6plex": ["N-term", "K"]
+    }
+
+.. tab:: TOML
+
+    .. code-block:: toml
+
+      [ms2rescore.fixed_modifications]
+      "U:Carbamidomethyl" = ["C"]
+      "U:TMT6plex" = ["N-term", "K"]
 
 
 .. caution::


### PR DESCRIPTION
### Changed
- 📝 Add instructions for adding fixed terminal modifications (See #125, compomics/psm_utils#71, and hupo-psi/proforma#6)