### PR TITLE
Fix ionmob in Windows installer 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install package and dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install --only-binary :all: . pyinstaller
+          pip install --only-binary :all: .[ionmob] pyinstaller
 
       - name: Install Inno Setup
         uses: crazy-max/ghaction-chocolatey@v3

--- a/ms2rescore.spec
+++ b/ms2rescore.spec
@@ -16,6 +16,8 @@ project = "ms2rescore"
 bundle_name = "ms2rescore"
 bundle_identifier = f"{bundle_name}.{__version__}"
 
+extra_requirements = {"ionmob"}
+
 # Requirements config
 skip_requirements_regex = r"^(?:.*\..*)"
 
@@ -28,6 +30,7 @@ requirements = {
     if "; extra ==" not in req  # Exclude optional dependencies
 }
 requirements.update([project, "xgboost"])
+requirements.update(extra_requirements)
 
 hidden_imports = set()
 datas = []


### PR DESCRIPTION
### Fixed

🚀 Fix ionmob in Windows installer (Optional dependencies must be added explicitly in build workflow).

