### PR TITLE
Fix: Pass IM2Deep config in GUI

### DIFF
--- a/ms2rescore/gui/app.py
+++ b/ms2rescore/gui/app.py
@@ -383,6 +383,9 @@ class FeatureGeneratorConfig(ctk.CTkFrame):
             config["deeplc"] = deeplc_config
         if ionmob_enabled:
             config["ionmob"] = ionmob_config
+        if im2deep_enabled:
+            config["im2deep"] = im2deep_config
+
         return config
 
 


### PR DESCRIPTION
### Fixed

- GUI: Ensure IM2Deep configuration is passed from GUI to MS²Rescore run