### PR TITLE
Fix bug in TIMS²Rescore configuration priority

### DIFF
--- a/ms2rescore/__main__.py
+++ b/ms2rescore/__main__.py
@@ -209,12 +209,12 @@ def main(tims=False):
     cli_args = parser.parse_args()
 
     configurations = []
-    if cli_args.config_file:
-        configurations.append(cli_args.config_file)
     if tims:
         configurations.append(
             json.load(importlib.resources.open_text(package_data, "config_default_tims.json"))
         )
+    if cli_args.config_file:
+        configurations.append(cli_args.config_file)
     configurations.append(cli_args)
 
     try:

--- a/ms2rescore/report/generate.py
+++ b/ms2rescore/report/generate.py
@@ -56,8 +56,8 @@ def generate_report(
     Parameters
     ----------
     output_path_prefix
-        Prefix of the MS²Rescore output file names. For example, if the PSM file is
-        ``/path/to/file.psms.tsv``, the prefix is ``/path/to/file.ms2rescore``.
+        Prefix of the MS²Rescore output file names. For example, if the output PSM file is
+        ``/path/to/file.ms2rescore.psms.tsv``, the prefix is ``/path/to/file.ms2rescore``.
     psm_list
         PSMs to be used for the report. If not provided, the PSMs will be read from the
         PSM file that matches the ``output_path_prefix``.


### PR DESCRIPTION
### Fixed

- 🐛 Fix bug where, if tims2rescore enabled, the default TIMS²Rescore configuration items always overwrote user configuration.