### PR TITLE
Pin DeepLC version to <3.1, avoiding calibration bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "cascade-config>=0.4.0",
     "click>=7",
     "customtkinter>=5,<6",
-    "deeplc>=3.1",
+    "deeplc>=3.0,<3.1",
     "deeplcretrainer",
     "im2deep>=0.1.3",
     "jinja2>=3",


### PR DESCRIPTION
Sibling PR of #197 to `main` branch, but to v3.1.3 branch