### PR TITLE
Fix silent crash due to XGBoost-CUDA environment variable incompatibility

### DIFF
--- a/ms2rescore/__init__.py
+++ b/ms2rescore/__init__.py
@@ -1,6 +1,10 @@
-"""MS²Rescore: Sensitive PSM rescoring with predicted MS² peak intensities and RTs."""
+"""Modular and user-friendly platform for AI-assisted rescoring of peptide identifications ."""
 
-__version__ = "3.2.0.dev1"
+__version__ = "3.2.0.dev2"
+__all__ = [
+    "parse_configurations",
+    "rescore",
+]
 
 from warnings import filterwarnings
 
@@ -12,5 +16,5 @@ filterwarnings(
     module="psims.mzmlb",
 )
 
-from ms2rescore.config_parser import parse_configurations  # noqa: F401 E402
-from ms2rescore.core import rescore  # noqa: F401 E402
+from ms2rescore.config_parser import parse_configurations  # noqa: E402
+from ms2rescore.core import rescore  # noqa: E402

--- a/ms2rescore/feature_generators/ms2pip.py
+++ b/ms2rescore/feature_generators/ms2pip.py
@@ -25,6 +25,7 @@ If you use MS²PIP through MS²Rescore, please cite:
 
 import logging
 import multiprocessing
+import os
 import warnings
 from itertools import chain
 from typing import List, Optional, Union
@@ -194,6 +195,7 @@ class MS2PIPFeatureGenerator(FeatureGeneratorBase):
                 spectrum_filename = infer_spectrum_path(self.spectrum_path, run)
                 logger.debug(f"Using spectrum file `{spectrum_filename}`")
                 try:
+                    os.environ.pop("CUDA_VISIBLE_DEVICES", None)
                     ms2pip_results = correlate(
                         psms=psm_list_run,
                         spectrum_file=str(spectrum_filename),


### PR DESCRIPTION
### Fixed

- 🐛 Avoid incompatibility between CUDA_VISIBLE_DEVICES env variable and XGBoost (see dmlc/xgboost#11283) that led to a crash without error messages.