### PR TITLE
Bump ms2rescore-rs and numpy dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "mokapot==0.10",  # 0.11.0 will introduce API changes
     "ms2pip>=4.0.0",
     "ms2rescore_rs>=0.4.2",
-    "numpy>=1.25",
+    "numpy>=2",
     "pandas>=1",
     "plotly>=5",
     "psm_utils>=1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "lxml>=4.5",
     "mokapot==0.10",  # 0.11.0 will introduce API changes
     "ms2pip>=4.0.0",
-    "ms2rescore_rs>=0.4.0",
+    "ms2rescore_rs>=0.4.2",
     "numpy>=1.25",
     "pandas>=1",
     "plotly>=5",


### PR DESCRIPTION
Bump dependencies to fix

- Numpy <2 issue: https://github.com/compomics/ms2rescore/issues/219
- ms2rescore-rs issue: https://github.com/compomics/ms2rescore/issues/213#event-17089340919
