### PR TITLE
Fix numpy v2 compatibility in DeepLC feature generator (np.inf)

### DIFF
--- a/ms2rescore/feature_generators/deeplc.py
+++ b/ms2rescore/feature_generators/deeplc.py
@@ -131,9 +131,9 @@ class DeepLCFeatureGenerator(FeatureGeneratorBase):
             for run, psms in runs.items():
                 peptide_rt_diff_dict = defaultdict(
                     lambda: {
-                        "observed_retention_time_best": np.Inf,
-                        "predicted_retention_time_best": np.Inf,
-                        "rt_diff_best": np.Inf,
+                        "observed_retention_time_best": np.inf,
+                        "predicted_retention_time_best": np.inf,
+                        "rt_diff_best": np.inf,
                     }
                 )
                 logger.info(


### PR DESCRIPTION
### Fixed

- Fix compatibility with Numpy 2 (usage of `inf` over `Inf`), fixes #219
