### PR TITLE
fix setting boolean command line arguments in config file

### DIFF
--- a/ms2rescore/__main__.py
+++ b/ms2rescore/__main__.py
@@ -150,6 +150,7 @@ def _argument_parser() -> argparse.ArgumentParser:
         "--write-report",
         # metavar="BOOL",
         action="store_true",
+        default=None,
         dest="write_report",
         help="boolean to enable profiling with cProfile",
     )
@@ -157,6 +158,7 @@ def _argument_parser() -> argparse.ArgumentParser:
         "--profile",
         # metavar="BOOL",
         action="store_true",
+        default=None,
         # type=bool,
         # dest="profile",
         help="boolean to enable profiling with cProfile",


### PR DESCRIPTION
The default value when using `store_true` parameters is `False`. As a result this will always overwrite any value set in the config file. This fixes this by changing the default to `None`, so a potential value in the config file is only overwritten when using the flag.